### PR TITLE
edit catch error

### DIFF
--- a/src/api/facilities/facilities.controller.ts
+++ b/src/api/facilities/facilities.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { AuthRequestFacilities } from '../../auth/auth.types.ts';
+import ErrorHandler from '../../utils/errorsHandlers.ts';
 import {
   getAllFacilities,
   getFacilityById,
@@ -12,14 +13,8 @@ export async function getAllFacilitiesHandler(req: Request, res: Response) {
   try {
     const facilities = await getAllFacilities();
     return res.status(200).json(facilities);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -33,14 +28,8 @@ export async function getFacilityByIdHandler(req: Request, res: Response) {
       });
     }
     return res.status(200).json(facility);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -49,14 +38,8 @@ export async function createFacilityHandler(req: Request, res: Response) {
     const data = req.body;
     const facility = await createFacility(data);
     return res.status(201).json(facility);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -71,14 +54,8 @@ export async function updateFacilityHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(facility);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -99,13 +76,7 @@ export async function deleteFacilityHandler(
     return await deleteFacility(id);
 
     res.status(200).json(facility);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }

--- a/src/api/facilities/facilities.controller.ts
+++ b/src/api/facilities/facilities.controller.ts
@@ -12,8 +12,14 @@ export async function getAllFacilitiesHandler(req: Request, res: Response) {
   try {
     const facilities = await getAllFacilities();
     return res.status(200).json(facilities);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -27,8 +33,14 @@ export async function getFacilityByIdHandler(req: Request, res: Response) {
       });
     }
     return res.status(200).json(facility);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -37,8 +49,14 @@ export async function createFacilityHandler(req: Request, res: Response) {
     const data = req.body;
     const facility = await createFacility(data);
     return res.status(201).json(facility);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -53,8 +71,14 @@ export async function updateFacilityHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(facility);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -75,7 +99,13 @@ export async function deleteFacilityHandler(
     return await deleteFacility(id);
 
     res.status(200).json(facility);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }

--- a/src/api/restaurants/restaurants.controller.ts
+++ b/src/api/restaurants/restaurants.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { AuthRequestRestaurants } from '../../auth/auth.types.ts';
+import ErrorHandler from '../../utils/errorsHandlers.ts';
 import {
   getAllRestaurants,
   getRestaurantById,
@@ -12,14 +13,8 @@ export async function getAllRestaurantsHandler(req: Request, res: Response) {
   try {
     const restaurants = await getAllRestaurants();
     return res.status(200).json(restaurants);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -35,14 +30,8 @@ export async function getRestaurantByIdHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(restaurant);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -53,14 +42,8 @@ export async function createRestaurantHandler(req: Request, res: Response) {
     const restaurant = await createRestaurant(data);
 
     return res.status(201).json(restaurant);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -77,14 +60,8 @@ export async function updateRestaurantHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(restaurant);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -103,13 +80,7 @@ export async function deleteRestaurantHandler(
     }
 
     return await deleteRestaurant(id);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }

--- a/src/api/restaurants/restaurants.controller.ts
+++ b/src/api/restaurants/restaurants.controller.ts
@@ -12,8 +12,14 @@ export async function getAllRestaurantsHandler(req: Request, res: Response) {
   try {
     const restaurants = await getAllRestaurants();
     return res.status(200).json(restaurants);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -29,8 +35,14 @@ export async function getRestaurantByIdHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(restaurant);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -41,8 +53,14 @@ export async function createRestaurantHandler(req: Request, res: Response) {
     const restaurant = await createRestaurant(data);
 
     return res.status(201).json(restaurant);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -59,8 +77,14 @@ export async function updateRestaurantHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(restaurant);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -79,7 +103,13 @@ export async function deleteRestaurantHandler(
     }
 
     return await deleteRestaurant(id);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }

--- a/src/api/reviews/reviews.controller.ts
+++ b/src/api/reviews/reviews.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { AuthRequestReviews } from '../../auth/auth.types.ts';
+import ErrorHandler from '../../utils/errorsHandlers.ts';
 import {
   getAllReviews,
   getReviewById,
@@ -12,14 +13,8 @@ export async function getAllReviewsHandler(req: Request, res: Response) {
   try {
     const reviews = await getAllReviews();
     return res.status(200).json(reviews);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -35,14 +30,8 @@ export async function getReviewByIdHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(review);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -51,14 +40,8 @@ export async function createReviewHandler(req: Request, res: Response) {
     const data = req.body;
     const review = await createReview(data);
     return res.status(201).json(review);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -73,14 +56,8 @@ export async function updateReviewHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(review);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -99,13 +76,7 @@ export async function deleteReviewHandler(
     }
 
     return await deleteReview(id);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }

--- a/src/api/reviews/reviews.controller.ts
+++ b/src/api/reviews/reviews.controller.ts
@@ -12,8 +12,14 @@ export async function getAllReviewsHandler(req: Request, res: Response) {
   try {
     const reviews = await getAllReviews();
     return res.status(200).json(reviews);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -29,8 +35,14 @@ export async function getReviewByIdHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(review);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -39,8 +51,14 @@ export async function createReviewHandler(req: Request, res: Response) {
     const data = req.body;
     const review = await createReview(data);
     return res.status(201).json(review);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -55,8 +73,14 @@ export async function updateReviewHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(review);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -75,7 +99,13 @@ export async function deleteReviewHandler(
     }
 
     return await deleteReview(id);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }

--- a/src/api/users/user.controller.ts
+++ b/src/api/users/user.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { Users } from './user.types.ts';
 import { AuthRequest } from '../../auth/auth.types.ts';
+import ErrorHandler from '../../utils/errorsHandlers.ts';
 
 import {
   getAllUsers,
@@ -15,14 +16,8 @@ export async function getAllUsersHandler(req: Request, res: Response) {
   try {
     const users = await getAllUsers();
     return res.status(200).send(users);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -39,14 +34,8 @@ export async function getUserByIdHandler(req: AuthRequest, res: Response) {
     }
 
     return res.status(200).send(user);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -63,14 +52,8 @@ export async function getUserByEmailHandler(req: AuthRequest, res: Response) {
     }
 
     return res.status(200).json(user);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -81,14 +64,8 @@ export async function createUserHandler(req: Request, res: Response) {
     const user = await createUser(data);
 
     return res.status(201).json(user);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -105,14 +82,8 @@ export async function updateUserHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(user);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 
@@ -128,13 +99,7 @@ export async function deleteUserHandler(req: AuthRequest, res: Response) {
     }
 
     return await deleteUser(id);
-  } catch (e: unknown) {
-    let message;
-    if (typeof e === 'string') {
-      message = e.toUpperCase();
-    } else if (e instanceof Error) {
-      message = e.message;
-    }
-    return res.status(400).send(message);
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }

--- a/src/api/users/user.controller.ts
+++ b/src/api/users/user.controller.ts
@@ -14,9 +14,15 @@ import {
 export async function getAllUsersHandler(req: Request, res: Response) {
   try {
     const users = await getAllUsers();
-    res.status(200).send(users);
-  } catch (ex: any) {
-    res.status(400).send(ex.toSting());
+    return res.status(200).send(users);
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -33,8 +39,14 @@ export async function getUserByIdHandler(req: AuthRequest, res: Response) {
     }
 
     return res.status(200).send(user);
-  } catch (ex: any) {
-    return res.status(400).send(ex.toSting());
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -51,8 +63,14 @@ export async function getUserByEmailHandler(req: AuthRequest, res: Response) {
     }
 
     return res.status(200).json(user);
-  } catch (ex: any) {
-    return res.status(400).send(ex.toSting());
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -63,8 +81,14 @@ export async function createUserHandler(req: Request, res: Response) {
     const user = await createUser(data);
 
     return res.status(201).json(user);
-  } catch (ex: any) {
-    return res.status(400).send(ex.toSting());
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -81,8 +105,14 @@ export async function updateUserHandler(req: Request, res: Response) {
     }
 
     return res.status(200).json(user);
-  } catch (ex: any) {
-    return res.status(400).send(ex.toSting());
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }
 
@@ -98,7 +128,13 @@ export async function deleteUserHandler(req: AuthRequest, res: Response) {
     }
 
     return await deleteUser(id);
-  } catch ({ message }: any) {
-    return res.status(400).json({ message });
+  } catch (e: unknown) {
+    let message;
+    if (typeof e === 'string') {
+      message = e.toUpperCase();
+    } else if (e instanceof Error) {
+      message = e.message;
+    }
+    return res.status(400).send(message);
   }
 }

--- a/src/auth/local/local.controller.ts
+++ b/src/auth/local/local.controller.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { getUserByEmail } from '../../api/users/user.services.ts';
 import { comparePassword } from '../utils/bycript.ts';
 import { signToken } from '../auth.services.ts';
+import ErrorHandler from '../../utils/errorsHandlers.ts';
 
 async function loginHandler(req: Request, res: Response) {
   const { email, password } = req.body;
@@ -33,9 +34,9 @@ async function loginHandler(req: Request, res: Response) {
       role: user.roleId,
     };
 
-    return res.status(200).json({ token, newUser });
-  } catch (error: any) {
-    return res.status(400).send({ message: error.message });
+    return res.status(200).send({ token, newUser });
+  } catch (e) {
+    return res.status(400).send(ErrorHandler);
   }
 }
 

--- a/src/auth/utils/bycript.ts
+++ b/src/auth/utils/bycript.ts
@@ -3,12 +3,16 @@ import bcrypt from 'bcrypt';
 export const hashPassword = async (password: string, factor?: number) => {
   const salt = await bcrypt.genSalt(factor);
 
-  await bcrypt.hash(password, salt);
+  const data = await bcrypt.hash(password, salt);
+
+  return data;
 };
 
 export const comparePassword = async (
   password: string,
   hashedPassword: string,
 ) => {
-  await bcrypt.compare(password, hashedPassword);
+  const comparePass = await bcrypt.compare(password, hashedPassword);
+
+  return comparePass;
 };

--- a/src/utils/errorsHandlers.ts
+++ b/src/utils/errorsHandlers.ts
@@ -1,0 +1,12 @@
+class ErrorHandler {
+  constructor(private exception: any) {
+    if (typeof exception === 'string') throw exception;
+    if (exception instanceof Error) throw exception.message;
+
+    throw new Error('Ha ocurrido un error');
+  }
+}
+
+export default {
+  ErrorHandler,
+};


### PR DESCRIPTION
## PR: Change in Error Handling

This Pull Request introduces a significant change in our error handling approach within the codebase. Previously, we relied on the generic `any` type to catch errors, which was error-prone and made code maintenance a challenging task. In this update, we've revamped our error handling logic to enhance both safety and code clarity.

### Proposed Changes

We've overhauled the error handling section in the code, replacing the usage of `any` with more specific types. Previously, it looked like this:

```typescript
class ErrorHandler {
  constructor(private exception: unknown) {
    if (typeof exception === 'string') throw exception;
    if (exception instanceof Error) throw exception.message;

    throw new Error('An error has occurred');
  }
}

export default {
  ErrorHandler,
};
